### PR TITLE
add tray icon menu to every view

### DIFF
--- a/apps/web/components/PageWrapper.tsx
+++ b/apps/web/components/PageWrapper.tsx
@@ -17,6 +17,7 @@ import AppProviders from "@lib/app-providers";
 import { seoConfig } from "@lib/config/next-seo.config";
 
 import { GoogleTagManagerComponent } from "@components/GTM";
+import { TrayIconComponent } from "@components/Tauri/TrayIcon";
 
 export interface CalPageWrapper {
   (props?: AppProps): JSX.Element;
@@ -67,6 +68,7 @@ function PageWrapper(props: AppProps) {
           content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover"
         />
       </Head>
+      {typeof window !== "undefined" && "__TAURIFY__" in window ? <TrayIconComponent /> : null}
       <DefaultSeo
         // Set canonical to https://cal.com or self-hosted URL
         canonical={

--- a/apps/web/components/Tauri/TrayIcon.tsx
+++ b/apps/web/components/Tauri/TrayIcon.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import type { SubmenuOptions } from "@crabnebula/taurify-api/menu";
+import { Menu } from "@crabnebula/taurify-api/menu";
+import { getCurrentWebviewWindow } from "@crabnebula/taurify-api/tauri/webviewWindow";
+import { TrayIcon } from "@crabnebula/taurify-api/tray";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import dayjs from "@calcom/dayjs";
+import { useLocale } from "@calcom/lib/hooks/useLocale";
+import type { RouterOutputs } from "@calcom/trpc/react";
+import { trpc } from "@calcom/trpc/react";
+
+import useMeQuery from "@lib/hooks/useMeQuery";
+
+async function focusAppWindow() {
+  const appWindow = getCurrentWebviewWindow();
+  appWindow.show();
+  appWindow.setFocus();
+}
+
+type RouterInstance = ReturnType<typeof useRouter>;
+type BookingOutput = RouterOutputs["viewer"]["bookings"]["get"]["bookings"][0];
+
+const getSeatReferenceUid = (booking: BookingOutput) => {
+  if (!booking.seatsReferences[0]) {
+    return undefined;
+  }
+  return booking.seatsReferences[0].referenceUid;
+};
+
+function bookingMenuItem(t: ReturnType<typeof useLocale>["t"], router: RouterInstance) {
+  return (booking: BookingOutput): SubmenuOptions => ({
+    text: booking.title,
+    items: [
+      {
+        text: t("cancel_event"),
+        action: async () => {
+          const isRecurring = booking.recurringEventId !== null;
+          router.push(`/booking/${booking.uid}?cancel=true${isRecurring ? "&allRemainingBookings=true" : ""}${
+            booking.seatsReferences.length ? `&seatReferenceUid=${getSeatReferenceUid(booking)}` : ""
+          }
+            `);
+
+          await focusAppWindow();
+        },
+      },
+      {
+        text: t("reschedule_booking"),
+        action: async () => {
+          router.push(
+            `/reschedule/${booking.uid}${
+              booking.seatsReferences.length ? `?seatReferenceUid=${getSeatReferenceUid(booking)}` : ""
+            }`
+          );
+
+          await focusAppWindow();
+        },
+      },
+    ],
+  });
+}
+
+export function TrayIconComponent() {
+  const user = useMeQuery().data;
+
+  const query = trpc.viewer.bookings.get.useInfiniteQuery(
+    {
+      limit: 10,
+      filters: {
+        status: "upcoming",
+      },
+    },
+    {
+      // first render has status `undefined`
+      enabled: true,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    }
+  );
+  const upcoming10Today = query.data?.pages.map((page) =>
+    page.bookings.filter((booking: BookingOutput) => {
+      return (
+        dayjs(booking.startTime).tz(user?.timeZone).format("YYYY-MM-DD") ===
+        dayjs().tz(user?.timeZone).format("YYYY-MM-DD")
+      );
+    })
+  )[0];
+
+  const router = useRouter();
+  const { t } = useLocale();
+
+  useEffect(() => {
+    async function updateTray() {
+      const trayIcon = await TrayIcon.getById("main");
+
+      const menu = await Menu.new({
+        items: user?.id ? (upcoming10Today || []).map(bookingMenuItem(t, router)) : [],
+      });
+
+      await trayIcon?.setMenu(menu);
+    }
+
+    if (typeof window !== "undefined" && "__TAURIFY__" in window && user?.id) {
+      console.info("Taurify is available on this page");
+      updateTray().catch(console.error);
+    }
+  }, [t, router, upcoming10Today, user]);
+
+  return null;
+}

--- a/apps/web/modules/bookings/views/bookings-listing-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-listing-view.tsx
@@ -1,12 +1,7 @@
 "use client";
 
-import type { SubmenuOptions } from "@crabnebula/taurify-api/menu";
-import { Menu } from "@crabnebula/taurify-api/menu";
-import { TrayIcon } from "@crabnebula/taurify-api/tray";
-import { getCurrentWebviewWindow } from "@crabnebula/taurify-api/webviewWindow";
 import { useAutoAnimate } from "@formkit/auto-animate/react";
-import { useRouter } from "next/navigation";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useState } from "react";
 import { z } from "zod";
 
 import { WipeMyCalActionButton } from "@calcom/app-store/wipemycalother/components";
@@ -83,13 +78,11 @@ export default function Bookings() {
   const { t } = useLocale();
   const user = useMeQuery().data;
   const [isFiltersVisible, setIsFiltersVisible] = useState<boolean>(false);
-  const router = useRouter();
 
   const query = trpc.viewer.bookings.get.useInfiniteQuery(
     {
       limit: 10,
       filters: {
-        ...filterQuery,
         status: filterQuery.status ?? status,
       },
     },
@@ -150,69 +143,6 @@ export default function Bookings() {
     )[0] || [];
 
   const [animationParentRef] = useAutoAnimate<HTMLDivElement>();
-
-  const getSeatReferenceUid = () => {
-    if (!booking.seatsReferences[0]) {
-      return undefined;
-    }
-    return booking.seatsReferences[0].referenceUid;
-  };
-
-  useEffect(() => {
-    const updateTrayMenu = async () => {
-      const trayIcon = await TrayIcon.getById("main");
-
-      async function focusAppWindow() {
-        const appWindow = getCurrentWebviewWindow();
-        appWindow.show();
-        appWindow.setFocus();
-      }
-
-      function bookingMenuItem(booking: BookingOutput): SubmenuOptions {
-        return {
-          text: booking.title,
-          items: [
-            {
-              text: t("cancel_event"),
-              action: async () => {
-                const isRecurring = booking.recurringEventId !== null;
-                const isTabRecurring = booking.listingStatus === "recurring";
-
-                router.push(`/booking/${booking.uid}?cancel=true${
-                  isTabRecurring && isRecurring ? "&allRemainingBookings=true" : ""
-                }${booking.seatsReferences.length ? `&seatReferenceUid=${getSeatReferenceUid()}` : ""}
-                `);
-
-                await focusAppWindow();
-              },
-            },
-            {
-              text: t("reschedule_booking"),
-              action: async () => {
-                router.push(
-                  `/reschedule/${booking.uid}${
-                    booking.seatsReferences.length ? `?seatReferenceUid=${getSeatReferenceUid()}` : ""
-                  }`
-                );
-
-                await focusAppWindow();
-              },
-            },
-          ],
-        };
-      }
-
-      const menu = await Menu.new({
-        items: bookingsToday.map(bookingMenuItem),
-      });
-
-      await trayIcon?.setMenu(menu);
-    };
-
-    if (typeof window !== "undefined" && "__TAURIFY__" in window) {
-      updateTrayMenu().catch(console.error);
-    }
-  }, [bookingsToday]);
 
   return (
     <Shell

--- a/apps/web/taurify.json
+++ b/apps/web/taurify.json
@@ -18,7 +18,8 @@
         "height": 800.0,
         "minWidth": 1000.0,
         "minHeight": 800.0,
-        "title": "Cal"
+        "hiddenTitle": true,
+        "titleBarStyle": "Transparent"
       }
     ],
     "singleInstance": true,


### PR DESCRIPTION
This PR creates a `<TrayIcon />` React component that checks for an existing user in the `useMeQuery`, then it grabs up to 10 upcoming events today and adds them to the Tray menu bar with Reschedule and Cancel action buttons.

If user is logged out, it only shows the Cal.com icon at the menu bar.